### PR TITLE
fix(path): handle bytes/memoryview keys in stringify_element (#472)

### DIFF
--- a/deepdiff/path.py
+++ b/deepdiff/path.py
@@ -311,6 +311,8 @@ def parse_path(path, root_element=DEFAULT_FIRST_ELEMENT, include_actions=False):
 
 
 def stringify_element(param, quote_str=None):
+    if isinstance(param, (bytes, memoryview)):
+        return repr(param)
     has_quote = "'" in param
     has_double_quote = '"' in param
     if has_quote and has_double_quote and not quote_str:


### PR DESCRIPTION
## Problem

Fixes #472.

`DeepDiff` raises `TypeError` when comparing dicts that contain `bytes` keys:

```python
from deepdiff import DeepDiff
DeepDiff({b'foo': 1}, {b'foobar': 1})
# TypeError: a bytes-like object is required, not 'str'
```

## Root Cause

`stringify_element()` in `deepdiff/path.py` uses `"'" in param` to detect single quotes before choosing a quoting style. For `bytes` (and `memoryview`) objects the `in` operator requires a `bytes` needle; passing a `str` raises `TypeError`.

The crash path:
```
→ _diff_dict detects key change
→ _report_result → _skip_this → level.path()
→ DictRelationship.get_param_repr()
  bytes ∈ deepdiff.helper.strings → stringify_element(b'foo', quote_str="'{}'")
  → "'" in b'foo'   # TypeError
```

## Fix

```diff
 def stringify_element(param, quote_str=None):
+    if isinstance(param, (bytes, memoryview)):
+        return repr(param)
     has_quote = "'" in param
     has_double_quote = '"' in param
```

`repr(b'foo')` → `"b'foo'"` is a valid Python expression that:
- does not require any additional quoting (the `b''` notation is already correct)
- round-trips back to the original bytes via `literal_eval`
- produces the expected path `root[b'foo']` when wrapped by `param_repr_format`

## Verification

```python
from deepdiff import DeepDiff

# Reproducer from issue — no longer crashes:
result = DeepDiff({b'foo': 1}, {b'foobar': 1})
print(result)
# {'dictionary_item_added': {"root[b'foobar']": 1},
#  'dictionary_item_removed': {"root[b'foo']": 1}}

# Existing string-key behaviour unchanged:
result2 = DeepDiff({'foo': 1}, {'bar': 1})
print(result2)
# {'dictionary_item_added': {"root['bar']": 1},
#  'dictionary_item_removed': {"root['foo']": 1}}
```
