### PR TITLE
fix: skip truncate_datetime for date and timedelta objects

### DIFF
--- a/deepdiff/helper.py
+++ b/deepdiff/helper.py
@@ -690,7 +690,7 @@ def datetime_normalize(
         datetime.timezone, "BaseTzInfo"
     ] = datetime.timezone.utc,
 ) -> Any:
-    if truncate_datetime:
+    if truncate_datetime and isinstance(obj, (datetime.datetime, datetime.time)):
         if truncate_datetime == 'second':
             obj = obj.replace(microsecond=0)
         elif truncate_datetime == 'minute':

--- a/tests/test_diff_datetime.py
+++ b/tests/test_diff_datetime.py
@@ -1,5 +1,5 @@
 import pytz
-from datetime import date, datetime, time, timezone
+from datetime import date, datetime, time, timedelta, timezone
 from deepdiff import DeepDiff
 
 
@@ -123,3 +123,17 @@ class TestDiffDatetime:
         assert not DeepDiff(d1, d2)
         assert not DeepDiff(d1, d2, ignore_order=True)
         assert not DeepDiff(d1, d2, truncate_datetime='second')
+
+    def test_truncate_datetime_with_date_and_timedelta(self):
+        """truncate_datetime must not be applied to types that cannot be truncated."""
+        for truncate_datetime in ('second', 'minute', 'hour', 'day'):
+            d1 = {"a": date(2020, 5, 17)}
+            d2 = {"a": date(2020, 5, 17)}
+            assert not DeepDiff(d1, d2, truncate_datetime=truncate_datetime)
+
+            d2 = {"a": date(2020, 5, 18)}
+            assert DeepDiff(d1, d2, truncate_datetime=truncate_datetime)
+
+            d1 = {"a": timedelta(days=1)}
+            d2 = {"a": timedelta(days=2)}
+            assert DeepDiff(d1, d2, truncate_datetime=truncate_datetime)


### PR DESCRIPTION
Fixes #564

`datetime_normalize` applied `truncate_datetime` to every value routed through it, so `DeepDiff(..., truncate_datetime=...)` raised `TypeError: replace() got an unexpected keyword argument 'microsecond'` for `datetime.date` values and `AttributeError` for `datetime.timedelta` values. `date` has no sub-day components to truncate and `timedelta` has no `replace()`, so the truncation is now applied only to `datetime` and `time` objects; truncation of those is unchanged.

Regression test added in `tests/test_diff_datetime.py`: it fails on `master` with the reported `TypeError` and passes with the fix.

This change was prepared with AI assistance; the regression test was run locally and fails without the fix.
