### PR TITLE
Honour force='yes' in stringify_param

### DIFF
--- a/deepdiff/model.py
+++ b/deepdiff/model.py
@@ -947,6 +947,9 @@ class ChildRelationship:
             else:
                 result = candidate if resurrected == param else None
 
+        if result is None and force == 'yes':
+            result = '(unrepresentable)'
+
         if result:
             result = ':' if self.param_repr_format is None else self.param_repr_format.format(result)
 

--- a/tests/test_diff_tree.py
+++ b/tests/test_diff_tree.py
@@ -121,6 +121,27 @@ class TestDeepDiffTree:
         assert change.path(force='yes') == 'root(unrepresentable)'
         assert change.path(force='fake') == 'root[2]'
 
+    def test_unrepresentable_dict_key_path(self):
+        class Id:
+            def __repr__(self):
+                return '<id>'
+
+            def __hash__(self):
+                return 1
+
+            def __eq__(self, other):
+                return isinstance(other, Id)
+
+        key = Id()
+        t1 = {key: 10}
+        t2 = {key: 20}
+        ddiff = DeepDiff(t1, t2, view='tree')
+        (change, ) = ddiff['values_changed']
+
+        # repr does not round-trip, so there is no parsable path
+        assert change.path() is None
+        assert change.path(force='yes') == 'root[(unrepresentable)]'
+
     def test_report_type_in_iterable(self):
         a = {"temp": ["a"]}
         b = {"temp": ["b"]}


### PR DESCRIPTION
`ChildRelationship.stringify_param` takes `force` and never reads it, so `path(force='yes')` returns None for the case its own docstring calls out.

`path()` documents it like this:

```
Returns None if the path is not representable as a string. This might be the case ...
because custom objects used as dictionary keys (then there is a path but it's not representable).

:param force: If 'yes':
    Will return a path including '(unrepresentable)' in place of non string-representable parts.
```

A custom object used as a dictionary key:

```python
class Id:
    def __repr__(self): return '<id>'
    def __hash__(self): return 1
    def __eq__(self, other): return isinstance(other, Id)

k = Id()
change = DeepDiff({k: 10}, {k: 20}, view='tree')['values_changed'][0]
change.path()             # None, correct
change.path(force='yes')  # None, documented as a path with '(unrepresentable)'
```

`repr` doesn't round-trip here, so `stringify_param` sets `result = None` and returns it whatever `force` says. `NonSubscriptableIterableRelationship.get_param_repr` does implement `force`, which is why the set case in `test_non_subscriptable_iterable_path` works and this one never has.

Three lines, in `stringify_param` where `force` already arrives.

One judgement call for you. The result goes through `param_repr_format`, so a dict key comes out as `root[(unrepresentable)]` while the existing set case is `root(unrepresentable)` because it bypasses the format. Brackets seemed right since the key is the part being replaced, but say the word if you'd rather have it raw. I left `force='fake'` alone.

Test is `test_unrepresentable_dict_key_path`, next to the set-case test. Suite goes 1258 to 1259, with the same 5 failures and 1 error before and after (they are in `test_serialization.py` and `test_lfucache.py` and predate this). Reverting only `model.py` fails the new test alone.
