### PR TITLE
Add include_regex_paths to DeepDiff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # DeepDiff Change log
 
 - Unreleased
+    - Added `include_regex_paths` to DeepDiff, the counterpart of `exclude_regex_paths`, so you can limit the report to paths matching one or more regexes (issue #395)
     - Fixed missing type changes between equal-comparing items inside ordered iterables, e.g. `DeepDiff([2], [2.0])` now reports the `int` → `float` change like `DeepDiff(2, 2.0)` and `DeepDiff({'a': 2}, {'a': 2.0})` already do (issue #605).
 
 - v9-1-0

--- a/deepdiff/diff.py
+++ b/deepdiff/diff.py
@@ -186,6 +186,7 @@ class DeepDiff(ResultDict, SerializationMixin, DistanceMixin, DeepDiffProtocol, 
                  include_obj_callback: Optional[Callable]=None,
                  include_obj_callback_strict: Optional[Callable]=None,
                  include_paths: Union[str, List[str], None]=None,
+                 include_regex_paths: Union[str, List[str], Pattern[str], List[Pattern[str]], None]=None,
                  iterable_compare_func: Optional[Callable]=None,
                  log_frequency_in_sec: int=0,
                  log_scale_similarity_threshold: float=0.1,
@@ -216,6 +217,7 @@ class DeepDiff(ResultDict, SerializationMixin, DistanceMixin, DeepDiffProtocol, 
         # that may receive _parameters without these keys.
         self.exclude_glob_paths = None
         self.include_glob_paths = None
+        self.include_regex_paths = None
         if kwargs:
             raise ValueError((
                 "The following parameter(s) are not valid: %s\n"
@@ -271,6 +273,7 @@ class DeepDiff(ResultDict, SerializationMixin, DistanceMixin, DeepDiffProtocol, 
             _include_exact, self.include_glob_paths = separate_wildcard_and_exact_paths(_include_set)
             self.include_paths = add_root_to_paths(_include_exact)
             self.exclude_regex_paths = convert_item_or_items_into_compiled_regexes_else_none(exclude_regex_paths)
+            self.include_regex_paths = convert_item_or_items_into_compiled_regexes_else_none(include_regex_paths)
             self.exclude_types = set(exclude_types) if exclude_types else None
             self.exclude_types_tuple = tuple(exclude_types) if exclude_types else None  # we need tuple for checking isinstance
             self.ignore_type_subclasses = ignore_type_subclasses
@@ -455,6 +458,8 @@ class DeepDiff(ResultDict, SerializationMixin, DistanceMixin, DeepDiffProtocol, 
         if not self._skip_this(change_level):
             if self._skip_report_for_include_glob(change_level):
                 return
+            if self._skip_report_for_include_regex(change_level):
+                return
             change_level.report_type = report_type
             tree = self.tree if local_tree is None else local_tree
             tree[report_type].add(change_level)
@@ -475,6 +480,8 @@ class DeepDiff(ResultDict, SerializationMixin, DistanceMixin, DeepDiffProtocol, 
 
         if not self._skip_this(level):
             if self._skip_report_for_include_glob(level):
+                return
+            if self._skip_report_for_include_regex(level):
                 return
             level.report_type = report_type
             level.additional[CUSTOM_FIELD] = extra_info
@@ -499,6 +506,21 @@ class DeepDiff(ResultDict, SerializationMixin, DistanceMixin, DeepDiffProtocol, 
         for gp in self.include_glob_paths:
             if gp.match_or_is_descendant(level_path):
                 return False
+        return True
+
+    def _skip_report_for_include_regex(self, level):
+        """When include_regex_paths is set, only keep a change whose path, or the
+        path of one of its ancestors, matches one of the patterns. Matching an
+        ancestor keeps its whole subtree, mirroring how exclude_regex_paths drops
+        one."""
+        if not self.include_regex_paths:
+            return False
+        up = level
+        while up is not None:
+            up_path = up.path()
+            if any(regex.search(up_path) for regex in self.include_regex_paths):
+                return False
+            up = up.up
         return True
 
     @staticmethod

--- a/deepdiff/docstrings/diff_doc.rst
+++ b/deepdiff/docstrings/diff_doc.rst
@@ -77,6 +77,10 @@ include_paths: list, default = None
     List of the only paths to include in the report. If only one item is in the list, you can pass it as a string.
     Supports :ref:`wildcard_paths_label`: use ``[*]`` to match one segment or ``[**]`` to match any depth.
 
+include_regex_paths: list, default = None
+    :ref:`include_regex_paths_label`
+    List of string regex paths or compiled regex path objects to limit the report to. Only paths matching one of the regexes, or living under a matching path, are reported. If only one item, you can pass it as a string or a regex compiled object.
+
 include_obj_callback: function, default = None
     :ref:`include_obj_callback_label`
     A function that takes the object and its path and returns a Boolean. If True is returned, the object is included in the results, otherwise it is excluded.

--- a/deepdiff/docstrings/exclude_paths.rst
+++ b/deepdiff/docstrings/exclude_paths.rst
@@ -126,5 +126,27 @@ example 2:
 Tip: DeepDiff is using re.search on the path. So if you want to force it to match from the beginning of the path, add `^` to the beginning of regex.
 
 
+.. _include_regex_paths_label:
+
+Include Regex Paths
+-------------------
+
+This is the counterpart of `exclude_regex_paths`. Pass `include_regex_paths` a set or list of path regexes and only the paths that match one of them are kept in the report. The items in the list could be raw regex strings or compiled regex objects.
+    >>> import re
+    >>> t1 = [{'a': 1, 'b': 2}, {'c': 4, 'b': 5}]
+    >>> t2 = [{'a': 9, 'b': 3}, {'c': 4, 'b': 8}]
+    >>> print(DeepDiff(t1, t2, include_regex_paths=r"root\[\d+\]\['b'\]"))
+    {'values_changed': {"root[0]['b']": {'new_value': 3, 'old_value': 2}, "root[1]['b']": {'new_value': 8, 'old_value': 5}}}
+    >>> include_path = re.compile(r"\['a'\]")
+    >>> print(DeepDiff(t1, t2, include_regex_paths=[include_path]))
+    {'values_changed': {"root[0]['a']": {'new_value': 9, 'old_value': 1}}}
+
+Just like `exclude_regex_paths`, DeepDiff uses re.search on the path. A regex that matches a parent path keeps that whole subtree, the same way excluding a parent drops its subtree.
+    >>> t1 = {"foo": {"bar": "potato", "veg": "x"}, "other": {"z": 1}}
+    >>> t2 = {"foo": {"bar": "banana", "veg": "y"}, "other": {"z": 2}}
+    >>> print(DeepDiff(t1, t2, include_regex_paths=r"root\['foo'\]$"))
+    {'values_changed': {"root['foo']['bar']": {'new_value': 'banana', 'old_value': 'potato'}, "root['foo']['veg']": {'new_value': 'y', 'old_value': 'x'}}}
+
+
 
 Back to :doc:`/index`

--- a/tests/test_diff_include_regex_paths.py
+++ b/tests/test_diff_include_regex_paths.py
@@ -1,0 +1,72 @@
+import re
+from deepdiff import DeepDiff
+
+
+class TestDeepDiffIncludeRegexPaths:
+
+    def test_include_regex_paths_single_string(self):
+        t1 = [{'a': 1, 'b': 2}, {'c': 4, 'b': 5}]
+        t2 = [{'a': 9, 'b': 3}, {'c': 4, 'b': 8}]
+        ddiff = DeepDiff(t1, t2, include_regex_paths=r"root\[\d+\]\['b'\]")
+        expected = {'values_changed': {
+            "root[0]['b']": {'new_value': 3, 'old_value': 2},
+            "root[1]['b']": {'new_value': 8, 'old_value': 5},
+        }}
+        assert expected == ddiff
+
+    def test_include_regex_paths_list(self):
+        t1 = {"a": 1, "b": 2, "c": 3}
+        t2 = {"a": 10, "b": 20, "c": 30}
+        ddiff = DeepDiff(t1, t2, include_regex_paths=[r"\['a'\]", r"\['c'\]"])
+        expected = {'values_changed': {
+            "root['a']": {'new_value': 10, 'old_value': 1},
+            "root['c']": {'new_value': 30, 'old_value': 3},
+        }}
+        assert expected == ddiff
+
+    def test_include_regex_paths_compiled(self):
+        t1 = [{'a': 1, 'b': 2}, {'c': 4, 'b': 5}]
+        t2 = [{'a': 9, 'b': 3}, {'c': 4, 'b': 8}]
+        pattern = re.compile(r"\['a'\]")
+        ddiff = DeepDiff(t1, t2, include_regex_paths=[pattern])
+        expected = {'values_changed': {"root[0]['a']": {'new_value': 9, 'old_value': 1}}}
+        assert expected == ddiff
+
+    def test_include_regex_paths_ancestor_keeps_subtree(self):
+        # Anchoring to a parent path should keep the whole subtree, the same way
+        # exclude_regex_paths on a parent drops the whole subtree.
+        t1 = {"foo": {"bar": "potato", "veg": "x"}, "other": {"z": 1}}
+        t2 = {"foo": {"bar": "banana", "veg": "y"}, "other": {"z": 2}}
+        ddiff = DeepDiff(t1, t2, include_regex_paths=r"root\['foo'\]$")
+        expected = {'values_changed': {
+            "root['foo']['bar']": {'new_value': 'banana', 'old_value': 'potato'},
+            "root['foo']['veg']": {'new_value': 'y', 'old_value': 'x'},
+        }}
+        assert expected == ddiff
+
+    def test_include_regex_paths_no_match(self):
+        t1 = {"a": 1, "b": 2}
+        t2 = {"a": 10, "b": 20}
+        ddiff = DeepDiff(t1, t2, include_regex_paths=r"\['does_not_exist'\]")
+        assert {} == ddiff
+
+    def test_include_regex_paths_added_and_removed(self):
+        t1 = {"keep": {"x": 1}, "drop": {"y": 1}}
+        t2 = {"keep": {"x": 1, "new": 9}, "drop": {}}
+        ddiff = DeepDiff(t1, t2, include_regex_paths=r"root\['keep'\]")
+        expected = {'dictionary_item_added': ["root['keep']['new']"]}
+        assert expected == ddiff
+
+    def test_include_regex_paths_default_unchanged(self):
+        t1 = {"a": 1, "b": 2}
+        t2 = {"a": 10, "b": 20}
+        assert DeepDiff(t1, t2) == DeepDiff(t1, t2, include_regex_paths=None)
+
+    def test_include_regex_paths_with_ignore_order(self):
+        t1 = {"nums": [1, 2, 3], "letters": ["a", "b"]}
+        t2 = {"nums": [3, 2, 1], "letters": ["a", "c"]}
+        ddiff = DeepDiff(t1, t2, include_regex_paths=r"root\['letters'\]", ignore_order=True)
+        expected = {'values_changed': {
+            "root['letters'][1]": {'new_value': 'c', 'old_value': 'b'},
+        }}
+        assert expected == ddiff


### PR DESCRIPTION
Closes #395.

This adds `include_regex_paths`, the regex counterpart to `exclude_regex_paths`. You give it one or more regexes (raw strings or compiled objects) and only the paths that match end up in the report, so it lines up with the exact `include_paths` and the glob `include_glob_paths` we already have.

```python
>>> from deepdiff import DeepDiff
>>> t1 = [{'a': 1, 'b': 2}, {'c': 4, 'b': 5}]
>>> t2 = [{'a': 9, 'b': 3}, {'c': 4, 'b': 8}]
>>> DeepDiff(t1, t2, include_regex_paths=r"root\[\d+\]\['b'\]")
{'values_changed': {"root[0]['b']": {'new_value': 3, 'old_value': 2}, "root[1]['b']": {'new_value': 8, 'old_value': 5}}}
```

Like exclude_regex_paths it runs re.search on the path, and a regex that matches a parent keeps that whole subtree the same way excluding a parent drops it. When the option is not set nothing changes, so existing behavior stays the same. I added tests, a changelog line, and docs right next to the exclude_regex_paths section.
