### PR TITLE
Show removed keys in colored view when a dict becomes empty

### DIFF
--- a/deepdiff/colored_view.py
+++ b/deepdiff/colored_view.py
@@ -93,7 +93,8 @@ class ColoredView:
             return '{...}' if isinstance(obj, dict) else '[...]'
 
         if isinstance(obj, dict):
-            if not obj:
+            removed_map = self._get_path_removed(path)
+            if not obj and not removed_map:
                 return '{}'
             items = []
             for key, value in obj.items():
@@ -103,7 +104,7 @@ class ColoredView:
                     items.append(f'{next_indent}{GREEN}"{key}": {self._colorize_json(value, new_path, indent + 1)}{RESET}')
                 else:
                     items.append(f'{next_indent}"{key}": {self._colorize_json(value, new_path, indent + 1)}')
-            for key, value in self._get_path_removed(path).items():
+            for key, value in removed_map.items():
                 new_path = f"{path}['{key}']" if isinstance(key, str) else f"{path}[{key}]"
                 items.append(f'{next_indent}{RED}"{key}": {self._colorize_json(value, new_path, indent + 1)}{RESET}')
             return '{\n' + ',\n'.join(items) + f'\n{current_indent}' + '}'

--- a/tests/test_colored_view.py
+++ b/tests/test_colored_view.py
@@ -164,6 +164,68 @@ def test_colored_compact_view_list_all_items_removed():
     assert result == expected
 
 
+def test_colored_view_dict_all_keys_removed():
+    """Test that removed keys are displayed when a dict becomes empty."""
+    t1 = {'a': 1}
+    t2 = {}
+
+    diff = DeepDiff(t1, t2, view=COLORED_VIEW)
+    result = str(diff)
+
+    expected = f'''{{
+  {RED}"a": {RED}1{RESET}{RESET}
+}}'''
+    assert result == expected
+
+
+def test_colored_view_nested_dict_all_keys_removed():
+    """Test that removed keys are displayed when a nested dict becomes empty."""
+    t1 = {'x': {'a': 1}}
+    t2 = {'x': {}}
+
+    diff = DeepDiff(t1, t2, view=COLORED_VIEW)
+    result = str(diff)
+
+    expected = f'''{{
+  "x": {{
+    {RED}"a": {RED}1{RESET}{RESET}
+  }}
+}}'''
+    assert result == expected
+
+
+def test_colored_compact_view_nested_dict_all_keys_removed():
+    """Test that removed keys are displayed when a nested dict becomes empty with compact view."""
+    t1 = {'x': {'a': 1}, 'y': {'z': 3}}
+    t2 = {'x': {}, 'y': {'z': 3}}
+
+    diff = DeepDiff(t1, t2, view=COLORED_COMPACT_VIEW)
+    result = str(diff)
+
+    expected = f'''{{
+  "x": {{
+    {RED}"a": {RED}1{RESET}{RESET}
+  }},
+  "y": {{...}}
+}}'''
+    assert result == expected
+
+
+def test_colored_view_empty_dict_without_removals():
+    """An empty dict with no removed keys under it is still displayed as {}."""
+    t1 = {'x': {}, 'y': 1}
+    t2 = {'x': {}, 'y': 2}
+
+    diff = DeepDiff(t1, t2, view=COLORED_VIEW)
+    result = str(diff)
+
+    expected = f'''{{
+  "x": {{}},
+  "y": {RED}1{RESET} -> {GREEN}2{RESET}
+}}'''
+    assert result == expected
+
+
 def test_colored_view_list_changes_deletions():
     t1 = [1, 5, 7, 3, 6]
     t2 = [1, 2, 3, 4]


### PR DESCRIPTION
## Problem

While investigating issue #575, I found a related edge case in ColoredView when a dictionary becomes empty after keys are removed.

In this case, the colored view could return before the removed-key handling was processed, resulting in the removed keys not being displayed correctly.

The original list/empty-list behavior reported in #575 is already fixed on the current dev branch, so this PR addresses the related dictionary case.

## Changes
Fix the early-return behavior in ColoredView
Ensure removed dictionary keys are shown when the dictionary becomes empty
Add regression tests covering the edge case

## Testing
Added regression tests for the dictionary case
Full test suite: 1277 passed, 44 skipped