### PR TITLE
docs(stats): update get_stats() example to current output (worker keys + counts)

### DIFF
--- a/deepdiff/docstrings/stats.rst
+++ b/deepdiff/docstrings/stats.rst
@@ -68,11 +68,15 @@ For example:
     >>>
     >>> diff = DeepDiff(t1, t2, ignore_order=True, cache_size=5000, cutoff_intersection_for_pairs=1)
     >>> pprint(diff.get_stats())
-    {'DIFF COUNT': 37,
-     'DISTANCE CACHE HIT COUNT': 0,
+    {'DIFF COUNT': 54,
+     'DISTANCE CACHE HIT COUNT': 9,
      'MAX DIFF LIMIT REACHED': False,
      'MAX PASS LIMIT REACHED': False,
-     'PASSES COUNT': 7}
+     'PASSES COUNT': 7,
+     'WORKER BATCH COUNT': 0,
+     'WORKER DIFF COUNT': 0,
+     'WORKER DISTANCE CACHE HIT COUNT': 0,
+     'WORKER PASSES COUNT': 0}
 
 
 Back to :doc:`/index`


### PR DESCRIPTION
Fix the `get_stats()` example in the Stats docs

The example output under "Get Stats" in `docstrings/stats.rst` is out of date. Since
the multiprocessing support landed in 9.1.0, `get_stats()` also returns four
aggregated worker counters that are always present (zeroed on a serial run):

- `WORKER DIFF COUNT`
- `WORKER PASSES COUNT`
- `WORKER DISTANCE CACHE HIT COUNT`
- `WORKER BATCH COUNT`

The documented example still shows the pre-9.1.0 dict, so it neither lists those keys
nor matches the current counter values. Running the example exactly as written now
gives:

```
>>> pprint(diff.get_stats())
{'DIFF COUNT': 54,
 'DISTANCE CACHE HIT COUNT': 9,
 'MAX DIFF LIMIT REACHED': False,
 'MAX PASS LIMIT REACHED': False,
 'PASSES COUNT': 7,
 'WORKER BATCH COUNT': 0,
 'WORKER DIFF COUNT': 0,
 'WORKER DISTANCE CACHE HIT COUNT': 0,
 'WORKER PASSES COUNT': 0}
```

This updates the example to that output. Docs-only change; the `WORKER *` keys being
present in serial mode is the intended behaviour and is already covered by
`tests/test_multiprocessing.py`.

(`docs/stats.rst` is a symlink to `deepdiff/docstrings/stats.rst`, so the single edit
covers both.)
